### PR TITLE
Use vectorized selection with xarray

### DIFF
--- a/rioxarray/extract-points.py
+++ b/rioxarray/extract-points.py
@@ -18,6 +18,7 @@ with fiona.open(pts_path, "r") as gpkg:
     points = [feature["geometry"] for feature in gpkg]
     
 coords = [point['coordinates'] for point in points]
+points_df = pd.DataFrame(coords, columns=['x', 'y'])
 
 ### raster stack
 band_names = ["B1", "B10", "B11", "B2", "B3", "B4", "B5", "B6", "B7", "B9"]
@@ -35,11 +36,8 @@ t_list = [None] * 10
 for i in range(10):
     tic = timeit.default_timer()
     
-    data = []
-    for (x, y) in coords:
-        vals = ras.sel(x = x, y = y, method = "nearest").values
-        data.append(vals.tolist())
-    data = pd.DataFrame(data, columns = band_names)
+    vals = ras.sel(x = points_df.x.to_xarray(), y = points_df.y.to_xarray(), method = "nearest")
+    data = vals.to_pandas().transpose()
     
     toc = timeit.default_timer()
     t_list[i] = round(toc - tic, 2)


### PR DESCRIPTION
Use vectorized selection instead of iteration. This gives more than 1000x speedup.

Tested on my machine.

Existing code
task;package;time
extract-points;rioxarray;44,26
extract-points;rioxarray;44,79
extract-points;rioxarray;46,4
extract-points;rioxarray;45,64
extract-points;rioxarray;46,77
extract-points;rioxarray;46,94
extract-points;rioxarray;47,95
extract-points;rioxarray;45,25
extract-points;rioxarray;45,09
extract-points;rioxarray;43,81


Updated code
task;package;time
extract-points-update;rioxarray;0,1
extract-points-update;rioxarray;0,08
extract-points-update;rioxarray;0,08
extract-points-update;rioxarray;0,08
extract-points-update;rioxarray;0,08
extract-points-update;rioxarray;0,07
extract-points-update;rioxarray;0,07
extract-points-update;rioxarray;0,06
extract-points-update;rioxarray;0,06
extract-points-update;rioxarray;0,06